### PR TITLE
Prevent drum machine from returning idx=16 after setting beat

### DIFF
--- a/AndroidApp/app/src/main/cpp/DrumMachine.cpp
+++ b/AndroidApp/app/src/main/cpp/DrumMachine.cpp
@@ -152,7 +152,7 @@ void DrumMachine::setBeat(int beatIdx){
     mBeatStartIndex = beatIdx;
     int64_t frameNum = quantizeBeatIdx(beatIdx);
     mCurrentFrame = frameNum;
-    LOGD("setBeat: beat %d => mCurrentFrame %lld", beatIdx, frameNum);
+    LOGD("setBeat: beat %d => mCurrentFrame %ld", beatIdx, frameNum);
 }
 
 /**
@@ -179,9 +179,17 @@ void DrumMachine::resetAll() {
 
 /**
  * Quantizes frame number & rounds beat to the right value if required
+ *
+ * Quantization: after conversion, the beat index is rounded to the nearest integer [0, kTotalBeat)
+ *
+ * @param frameNum - index of frame
+ * @return index of beat
  */
 int DrumMachine::getBeatIdx(int64_t frameNum) {
-    return quantizeFrameNum(frameNum) % kTotalBeat;
+    /* Return the beat idx of a given frameNum, after quantization*/
+    float framePerBeat = round((60.0f / mTempo) * kSampleRateHz);
+    int beatIdx = static_cast<int>(round((float)frameNum / framePerBeat));
+    return beatIdx % kTotalBeat;
 }
 
 /**
@@ -220,23 +228,8 @@ void DrumMachine::processUpdateEvents() {
         int beatIdx = getBeatIdx(frameNum);
         mBeatMap[trackIdx][beatIdx] = 1;
         mUpdateEvents.pop();
-        LOGD("[processUpdateEvent] event(%lld,%d)-> beat_idx: %d", frameNum, trackIdx, beatIdx);
+        LOGD("[processUpdateEvent] event(%ld,%d)-> beat_idx: %d", frameNum, trackIdx, beatIdx);
     }
-}
-
-/**
- * Convert the index of frame to the index of beat with quantization
- *
- * Quantization: after conversion, the beat index is rounded to the nearest integer
- *
- * @param frameNum - index of frame
- * @return index of beat
- */
-int DrumMachine::quantizeFrameNum(int64_t frameNum) {
-    /* Return the beat idx of a given frameNum, after quantization*/
-    float framePerBeat = round((60.0f / mTempo) * kSampleRateHz);
-    int beatIdx = static_cast<int>(round((float)frameNum / framePerBeat));
-    return beatIdx;
 }
 
 /**

--- a/AndroidApp/app/src/main/cpp/DrumMachine.cpp
+++ b/AndroidApp/app/src/main/cpp/DrumMachine.cpp
@@ -178,6 +178,13 @@ void DrumMachine::resetAll() {
 }
 
 /**
+ * Quantizes frame number & rounds beat to the right value if required
+ */
+int DrumMachine::getBeatIdx(int64_t frameNum) {
+    return quantizeFrameNum(frameNum) % kTotalBeat;
+}
+
+/**
  * Add a beat to a given track, at the current playback position
  *
  * The function comprises of two steps:
@@ -194,7 +201,7 @@ int DrumMachine::insertBeat(int trackIdx) {
     // update beat map at the end of the loop
     int64_t currentFrame = mCurrentFrame;
     mUpdateEvents.push(std::make_tuple(currentFrame, trackIdx));
-    return quantizeFrameNum(currentFrame);
+    return getBeatIdx(currentFrame);
 }
 
 /**
@@ -210,7 +217,7 @@ void DrumMachine::processUpdateEvents() {
         nextUpdateEvent = mUpdateEvents.front();
         int64_t frameNum = std::get<0>(nextUpdateEvent);
         int trackIdx = std::get<1>(nextUpdateEvent);
-        int beatIdx = quantizeFrameNum(frameNum);
+        int beatIdx = getBeatIdx(frameNum);
         mBeatMap[trackIdx][beatIdx] = 1;
         mUpdateEvents.pop();
         LOGD("[processUpdateEvent] event(%lld,%d)-> beat_idx: %d", frameNum, trackIdx, beatIdx);

--- a/AndroidApp/app/src/main/cpp/DrumMachine.h
+++ b/AndroidApp/app/src/main/cpp/DrumMachine.h
@@ -56,7 +56,6 @@ private:
     void preparePlayerEvents();
     void processUpdateEvents();
     int getBeatIdx(int64_t frameNum);
-    int quantizeFrameNum(int64_t frameNum);
     int64_t quantizeBeatIdx(int beat_idx);
     void printBeatMap();
     void refreshLoop();

--- a/AndroidApp/app/src/main/cpp/DrumMachine.h
+++ b/AndroidApp/app/src/main/cpp/DrumMachine.h
@@ -55,6 +55,7 @@ public:
 private:
     void preparePlayerEvents();
     void processUpdateEvents();
+    int getBeatIdx(int64_t frameNum);
     int quantizeFrameNum(int64_t frameNum);
     int64_t quantizeBeatIdx(int beat_idx);
     void printBeatMap();


### PR DESCRIPTION
Drum machine sometimes returns beat_idx = 16, if we set a beat when the seekbar is at the end.
This crashes the UI since col 16 doesn't exist.

Probably just needs some rounding. 

Is there a need to edit "void DrumMachine::setBeat(int beatIdx)"?

